### PR TITLE
Remove use strict

### DIFF
--- a/.electron-vue/build.js
+++ b/.electron-vue/build.js
@@ -1,5 +1,3 @@
-'use strict'
-
 process.env.NODE_ENV = 'production'
 
 const { say } = require('cfonts')

--- a/.electron-vue/dev-runner.js
+++ b/.electron-vue/dev-runner.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const chalk = require('chalk')
 const electron = require('electron')
 const path = require('path')

--- a/.electron-vue/webpack.main.config.js
+++ b/.electron-vue/webpack.main.config.js
@@ -1,5 +1,3 @@
-'use strict'
-
 process.env.BABEL_ENV = 'main'
 
 const path = require('path')

--- a/.electron-vue/webpack.renderer.config.js
+++ b/.electron-vue/webpack.renderer.config.js
@@ -1,5 +1,3 @@
-'use strict'
-
 process.env.BABEL_ENV = 'renderer'
 
 const path = require('path')

--- a/.electron-vue/webpack.web.config.js
+++ b/.electron-vue/webpack.web.config.js
@@ -1,5 +1,3 @@
-'use strict'
-
 process.env.BABEL_ENV = 'web'
 
 const path = require('path')

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-let config = {
+const config = {
   // Use ESLint (extends `standard`)
   // Further changes can be made in `.eslintrc.js`
   eslint: true,

--- a/config.js
+++ b/config.js
@@ -1,5 +1,3 @@
-'use strict'
-
 let config = {
   // Use ESLint (extends `standard`)
   // Further changes can be made in `.eslintrc.js`

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { app, BrowserWindow, ipcMain } from 'electron'
 import Authentication from './authentication'
 

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const exec = require('child_process').exec
 const packager = require('electron-packager')
 

--- a/tasks/runner.js
+++ b/tasks/runner.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const config = require('../config')
 const exec = require('child_process').exec
 const treeKill = require('tree-kill')


### PR DESCRIPTION
### Description

[What does this PR add/change/fix?]

Hello,

In this PR, I removed the usage of `'use strict'` which is [not necessary in ES6 modules](http://www.ecma-international.org/ecma-262/6.0/#sec-strict-mode-code) because they are always in strict mode.

### Requirements

<!-- This needs to be followed for a PR to be accepted -->

* [x] Followed code style

### What's to be done

<!-- 
If your Pull Request is not finished yet, feel free to add a checklist with missing tasks here.
-->